### PR TITLE
klte-common: Remove libsecril-client*

### DIFF
--- a/klte.mk
+++ b/klte.mk
@@ -133,7 +133,6 @@ PRODUCT_PACKAGES += \
 # Radio
 PRODUCT_PACKAGES += \
     libsecnativefeature \
-    libsecril-client \
     libshim_ril
 
 # Ramdisk


### PR DESCRIPTION
* These are only required for some OEM blobs, and not even any
  that we make use of:
  * system/bin/smdexe matches
  * system/bin/vpnclientd matches
  * system/bin/connfwexe matches
  * system/bin/at_distributor matches
  * system/bin/wpa_supplicant matches
  * system/etc/irremovable_list.txt:/system/lib/libsecril-client.so
  * system/lib/hw/lights.msm8974.so matches
  * system/lib/hw/audio.primary.msm8974.so matches
  * system/lib/libcpve-client.so matches
  * system/lib/libaudio-ril.so matches
  * system/lib/libsecril-client.so matches

Change-Id: I7488681c9c1c15c1a42ba9a718c426c80526db19